### PR TITLE
scripts:project-sim.mk: Fix false failures

### DIFF
--- a/scripts/project-sim.mk
+++ b/scripts/project-sim.mk
@@ -25,7 +25,7 @@ $(strip $(1)) >> $(strip $(2)) 2>&1; \
 (ERR=$$?; \
 END=$$(date +%s); \
 DIFF=$$(( $$END - $$START )); \
-ERRS=`grep -v ^# $(2) | grep -w -i -e error -e fatal -e fatal_error -C 10`; \
+ERRS=`grep -v ^# $(2) | grep -w -i -e ^error -e ^fatal -e ^fatal_error -C 10`; \
 if [[ $$ERRS > 0 ]] ; then ERR=1; fi;\
 JUnitFile='results/$(strip $(4))_$(strip $(5)).xml'; \
 echo \<testsuite\> > $$JUnitFile; \


### PR DESCRIPTION
Add ^ in grep command in order to search for "error" or "fail"
only at the beggining of the lines.
This change is affecting only generation of jenkins Junit File.